### PR TITLE
System Text example, avoid attributes and made fields public

### DIFF
--- a/src/Wallets/Json/AccountKeys.cs
+++ b/src/Wallets/Json/AccountKeys.cs
@@ -1,6 +1,5 @@
 using Concordium.Sdk.Crypto;
 using Concordium.Sdk.Types;
-using Newtonsoft.Json;
 
 namespace Concordium.Sdk.Wallets.Json;
 
@@ -9,30 +8,24 @@ namespace Concordium.Sdk.Wallets.Json;
 /// <c>accountKeys</c> field of the browser and genesis wallet
 /// export JSON formats.
 ///
-/// Such can be parsed into an instance of this class using
-/// <see cref="JsonConvert"/>.
-///
 /// The object indexed by this field holds the sign keys and can
 /// be parsed into a map from pairs of <see cref="AccountCredentialIndex"/>
 /// and <see cref="AccountKeyIndex"/>es to <see cref="Ed25519SignKey"/>s
 /// using <see cref="TryGetSignKeys"/>.
 /// </summary>
-internal record AccountKeys
+public record AccountKeys
 {
-    internal record KeyInfo
+    public record KeyInfo
     {
-        internal record Key
+        public record Key
         {
-            [JsonProperty("signKey", Required = Required.DisallowNull)]
-            internal string? SignKeyField { get; init; }
+            public string SignKey { get; init; }
         };
 
-        [JsonProperty("keys", Required = Required.DisallowNull)]
-        internal Dictionary<string, Key>? KeysField { get; init; }
+        public Dictionary<string, Key> Keys { get; init; }
     }
 
-    [JsonProperty("keys", Required = Required.DisallowNull)]
-    internal Dictionary<string, KeyInfo>? KeysField { get; init; }
+    public Dictionary<string, KeyInfo> Keys { get; init; }
 
     /// <summary>
     /// Try to parse the sign keys into a map from pairs of
@@ -44,15 +37,15 @@ internal record AccountKeys
     /// <exception cref="ArgumentNullException">An index or sign key could not be parsed.</exception>
     public Dictionary<AccountCredentialIndex, Dictionary<AccountKeyIndex, ISigner>> TryGetSignKeys()
     {
-        if (this.KeysField is null)
+        if (this.Keys is null)
         {
             throw new WalletDataSourceException("Required field 'keys' is missing.");
         }
 
-        return this.KeysField
+        return this.Keys
             .Select(cred =>
             {
-                if (cred.Value.KeysField is null)
+                if (cred.Value.Keys is null)
                 {
                     throw new WalletDataSourceException("Required field 'keys' is missing.");
                 }
@@ -61,10 +54,10 @@ internal record AccountKeys
                 var accountCredentialIndex = AccountCredentialIndex.From(cred.Key);
 
                 // Then process its keys.
-                var keysForCredential = cred.Value.KeysField
+                var keysForCredential = cred.Value.Keys
                     .Select(key =>
                     {
-                        if (key.Value.SignKeyField is null)
+                        if (key.Value.SignKey is null)
                         {
                             throw new WalletDataSourceException(
                                 "Required field 'signKey' is missing."
@@ -75,7 +68,7 @@ internal record AccountKeys
                         var accountKeyIndex = AccountKeyIndex.From(key.Key);
 
                         // Then parse the key.
-                        ISigner signer = Ed25519SignKey.From(key.Value.SignKeyField);
+                        ISigner signer = Ed25519SignKey.From(key.Value.SignKey);
                         return new KeyValuePair<AccountKeyIndex, ISigner>(accountKeyIndex, signer);
                     })
                     .ToDictionary(kv => kv.Key, kv => kv.Value);

--- a/src/Wallets/Json/BrowserWalletExportFormat.cs
+++ b/src/Wallets/Json/BrowserWalletExportFormat.cs
@@ -1,44 +1,37 @@
 using Concordium.Sdk.Crypto;
 using Concordium.Sdk.Types;
 
-using Newtonsoft.Json;
-
 namespace Concordium.Sdk.Wallets.Json;
 
 /// <summary>
 /// Represents (a subset of) a JSON object which is in the
 /// browser wallet key export format.
 ///
-/// Such can be parsed into an instance of this class using
-/// <see cref="JsonConvert"/>.
 /// </summary>
-internal record BrowserWalletExportFormat : IWalletDataSource
+public record BrowserWalletExportFormat : IWalletDataSource
 {
-    internal record Value
+    public record ValueField
     {
-        [JsonProperty("accountKeys", Required = Required.DisallowNull)]
-        internal AccountKeys? AccountKeysField { get; init; }
+        public AccountKeys AccountKeys { get; init; }
 
-        [JsonProperty("address", Required = Required.DisallowNull)]
-        internal string? AddressField { get; init; }
+        public string Address { get; init; }
     }
 
-    [JsonProperty("value", Required = Required.DisallowNull)]
-    internal Value? ValueField { get; init; }
+    public ValueField Value { get; init; }
 
     public AccountAddress TryGetAccountAddress()
     {
-        if (this.ValueField is null)
+        if (this.Value is null)
         {
             throw new WalletDataSourceException("Required field 'value' is missing.");
         }
-        if (this.ValueField.AddressField is null)
+        if (this.Value.Address is null)
         {
             throw new WalletDataSourceException("Required field 'address' is missing.");
         }
         try
         {
-            return AccountAddress.From(this.ValueField.AddressField);
+            return AccountAddress.From(this.Value.Address);
         }
         catch (Exception e)
         {
@@ -51,17 +44,17 @@ internal record BrowserWalletExportFormat : IWalletDataSource
 
     public Dictionary<AccountCredentialIndex, Dictionary<AccountKeyIndex, ISigner>> TryGetSignKeys()
     {
-        if (this.ValueField is null)
+        if (this.Value is null)
         {
             throw new WalletDataSourceException("Required field 'value' is missing.");
         }
-        if (this.ValueField.AccountKeysField is null)
+        if (this.Value.AccountKeys is null)
         {
             throw new WalletDataSourceException("Required field 'accountKeys' is missing.");
         }
         try
         {
-            return this.ValueField.AccountKeysField.TryGetSignKeys();
+            return this.Value.AccountKeys.TryGetSignKeys();
         }
         catch (Exception e)
         {

--- a/src/Wallets/Json/GenesisWalletExportFormat.cs
+++ b/src/Wallets/Json/GenesisWalletExportFormat.cs
@@ -1,34 +1,27 @@
 using Concordium.Sdk.Crypto;
 using Concordium.Sdk.Types;
 
-using Newtonsoft.Json;
-
 namespace Concordium.Sdk.Wallets.Json;
 
 /// <summary>
 /// Represents (a subset of) a JSON object which is in the
 /// genesis wallet key export format.
-///
-/// Such can be parsed into an instance of this class using
-/// <see cref="JsonConvert"/>.
 /// </summary>
-internal record GenesisWalletExportFormat : IWalletDataSource
+public record GenesisWalletExportFormat : IWalletDataSource
 {
-    [JsonProperty("accountKeys", Required = Required.DisallowNull)]
-    internal AccountKeys? AccountKeysField { get; init; }
+    public AccountKeys AccountKeys { get; init; }
 
-    [JsonProperty("address", Required = Required.DisallowNull)]
-    internal string? AddressField { get; init; }
+    public string Address { get; init; }
 
     public AccountAddress TryGetAccountAddress()
     {
-        if (this.AddressField is null)
+        if (this.Address is null)
         {
             throw new WalletDataSourceException("Required field 'address' is missing.");
         }
         try
         {
-            return AccountAddress.From(this.AddressField);
+            return AccountAddress.From(this.Address);
         }
         catch (Exception e)
         {
@@ -41,13 +34,13 @@ internal record GenesisWalletExportFormat : IWalletDataSource
 
     public Dictionary<AccountCredentialIndex, Dictionary<AccountKeyIndex, ISigner>> TryGetSignKeys()
     {
-        if (this.AccountKeysField is null)
+        if (this.AccountKeys is null)
         {
             throw new WalletDataSourceException("Required field 'accountKeys' is missing.");
         }
         try
         {
-            return this.AccountKeysField.TryGetSignKeys();
+            return this.AccountKeys.TryGetSignKeys();
         }
         catch (Exception e)
         {

--- a/src/Wallets/WalletAccount.cs
+++ b/src/Wallets/WalletAccount.cs
@@ -1,8 +1,9 @@
 using System.Collections.Immutable;
+using System.Text.Json;
 using Concordium.Sdk.Crypto;
 using Concordium.Sdk.Transactions;
 using Concordium.Sdk.Types;
-using Newtonsoft.Json;
+
 
 namespace Concordium.Sdk.Wallets;
 
@@ -18,6 +19,13 @@ namespace Concordium.Sdk.Wallets;
 /// </summary>
 public class WalletAccount : ITransactionSigner
 {
+    private static readonly JsonSerializerOptions _options = new JsonSerializerOptions
+    {
+        AllowTrailingCommas = true,
+        IncludeFields = true,
+        PropertyNameCaseInsensitive = true,
+    };
+
     /// <summary>
     /// The address of the imported account.
     /// </summary>
@@ -76,7 +84,7 @@ public class WalletAccount : ITransactionSigner
             {
                 return FromBrowserWalletKeyExportFormat(json);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
                 throw e;
             }
@@ -91,8 +99,7 @@ public class WalletAccount : ITransactionSigner
     /// <exception cref="WalletDataSourceException">Either a field is missing or an index or sign key could not be parsed.</exception>
     private static WalletAccount FromGenesisWalletKeyExportFormat(string json)
     {
-        var genesisWallet =
-            JsonConvert.DeserializeObject<Json.GenesisWalletExportFormat>(json)
+        var genesisWallet = JsonSerializer.Deserialize<Json.GenesisWalletExportFormat>(json, _options)
             ?? throw new WalletDataSourceException(
                 "Call to DeserializeObject did not return a value."
             );
@@ -108,7 +115,7 @@ public class WalletAccount : ITransactionSigner
     private static WalletAccount FromBrowserWalletKeyExportFormat(string json)
     {
         var genesisWallet =
-            JsonConvert.DeserializeObject<Json.BrowserWalletExportFormat>(json)
+            JsonSerializer.Deserialize<Json.BrowserWalletExportFormat>(json, _options)
             ?? throw new WalletDataSourceException(
                 "Call to DeserializeObject did not return a value."
             );

--- a/src/Wallets/WalletAccount.cs
+++ b/src/Wallets/WalletAccount.cs
@@ -21,8 +21,6 @@ public class WalletAccount : ITransactionSigner
 {
     private static readonly JsonSerializerOptions _options = new JsonSerializerOptions
     {
-        AllowTrailingCommas = true,
-        IncludeFields = true,
         PropertyNameCaseInsensitive = true,
     };
 
@@ -84,7 +82,7 @@ public class WalletAccount : ITransactionSigner
             {
                 return FromBrowserWalletKeyExportFormat(json);
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 throw e;
             }

--- a/tests/Tests/UnitTests/Wallets/WalletAccountTests.cs
+++ b/tests/Tests/UnitTests/Wallets/WalletAccountTests.cs
@@ -115,6 +115,6 @@ public class WalletAccountTests
     public void FromWalletKeyExportFormat_OnNonJsonInput_ThrowsException()
     {
         Action result = () => WalletAccount.FromWalletKeyExportFormat("Not JSON.");
-        result.Should().Throw<Newtonsoft.Json.JsonException>();
+        result.Should().Throw<System.Text.Json.JsonException>();
     }
 }


### PR DESCRIPTION
## Purpose

Generally you would want to use System.Text since NewtonSoft is slow - and System.Text has improved a lot in it’s UX.

Here is a example how it can be used,
