### PR TITLE
Remove type parameters in comments to appease docfx.

### DIFF
--- a/src/Transactions/PreparedAccountTransaction.cs
+++ b/src/Transactions/PreparedAccountTransaction.cs
@@ -34,7 +34,7 @@ public record PreparedAccountTransaction
     public AccountTransactionPayload Payload { get; init; }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="PreparedAccountTransaction{T}"/> class.
+    /// Initializes a new instance of the <see cref="PreparedAccountTransaction"/> class.
     /// </summary>
     /// <param name="sender">Address of the sender of the transaction.</param>
     /// <param name="sequenceNumber">Account sequence number to use for the transaction.</param>

--- a/src/Transactions/SignedAccountTransaction.cs
+++ b/src/Transactions/SignedAccountTransaction.cs
@@ -30,7 +30,7 @@ public record SignedAccountTransaction
     public AccountTransactionSignature Signature { get; init; }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="SignedAccountTransaction{T}"/> class.
+    /// Initializes a new instance of the <see cref="SignedAccountTransaction"/> class.
     /// </summary>
     /// <param name="data">Header of the signed account transaction.</param>
     /// <param name="payload">Payload of the signed account transaction.</param>


### PR DESCRIPTION
## Purpose

Unnecessary type parameters were removed from a class, but were still present in some comments. Docfx will complain about this.

## Changes

Remove the offending type parameters.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.