### PR TITLE
Fix package name

### DIFF
--- a/src/Concordium.Sdk.csproj
+++ b/src/Concordium.Sdk.csproj
@@ -15,7 +15,7 @@
     <RepositoryUrl>https://github.com/Concordium/concordium-net-sdk</RepositoryUrl>
     <PackageTags>concordium;concordium-net-sdk;blockchain;sdk;</PackageTags>
     <Company>Concordium</Company>
-    <PackageId>Concordium.Sdk</PackageId>
+    <PackageId>ConcordiumNetSdk</PackageId>
     <Version>2.0.0</Version>
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
## Purpose

In version one the project was named ConcordiumNetSdk which it inherit from the `.csproj` file, https://github.com/Concordium/concordium-net-sdk/blob/6a2288b6b6eaf766517bc5a8f954ba6b5da8c392/src/ConcordiumNetSdk/ConcordiumNetSdk.csproj.

In the v.2 bump the projected was renamed to `Concordium.Sdk` and this gives issues when pushing the nuget package since the name has changed.
This PR renames the packed project to the old naming, such that package can be published to same nuget repository.

## Changes

Change packaged name to be consistent with old name.