### PR TITLE
Fix example links

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ Note that all generated types live in the [`Concordium.Grpc.V2`](http://develope
 
 A number of runnable examples illustrating usage of the SDK API are contained in the [examples](https://github.com/Concordium/concordium-net-sdk/main/examples) directory:
 
-- [examples/RawClient](https://github.com/Concordium/concordium-net-sdk/main/examples/RawClient) demonstrates usage of the raw API methods exposed in [`RawClient`](http://developer.concordium.software/concordium-net-sdk/api/Concordium.Sdk.Client.RawClient.html).
-- [examples/Transactions](https://github.com/Concordium/concordium-net-sdk/main/examples/Transactions) demonstrates how to work with the various transaction types.
+- [examples/RawClient](https://github.com/Concordium/concordium-net-sdk/tree/main/examples/Examples/RawClient) demonstrates usage of the raw API methods exposed in [`RawClient`](http://developer.concordium.software/concordium-net-sdk/api/Concordium.Sdk.Client.RawClient.html).
+- [examples/Transactions](https://github.com/Concordium/concordium-net-sdk/tree/main/examples/Examples/Transactions) demonstrates how to work with the various transaction types.
 
 For instance, a runnable example akin to that given in [Working with account transactions](#working-with-account-transactions) is found in [examples/Transactions/Transfer](https://github.com/Concordium/concordium-net-sdk/main/examples/Transactions/Transfer). Compiling the project and running the resulting binary will print the following help message:
 


### PR DESCRIPTION
## Purpose

Fix example links in README (and thus also in the generated docs).
I am not sure whether we _need_ the nested example folders (`./examples/Examples/..`), but this at least fixes the links.

## Changes

- Change links

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.