### PR TITLE
Rename MissingDelegationAddParameter to MissingDelegationAddParameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   - Property `Timeout` moved into `Options` in class `RawClient`. `Timeout` now defaults to 'indefinitely' compared to 30 seconds in obsolete constructor of `ConcordiumClient`.
   - `AccountTransactionType` is renamed to `TransactionType`.
   - Bugfix: Record `InvalidInitMethod` had parameter change from `ContractName` to `InitName`.
+  - Bugfix: Renamed `MissingDelegationAddParameter` to `MissingDelegationAddParameters`.
 
 
 ## 2.0.0

--- a/src/Types/RejectReason.cs
+++ b/src/Types/RejectReason.cs
@@ -93,7 +93,7 @@ internal static class RejectReasonFactory
             Grpc.V2.RejectReason.ReasonOneofCase.AlreadyADelegator => new AlreadyADelegator(),
             Grpc.V2.RejectReason.ReasonOneofCase.InsufficientBalanceForDelegationStake =>
                 new InsufficientBalanceForDelegationStake(),
-            Grpc.V2.RejectReason.ReasonOneofCase.MissingDelegationAddParameters => new MissingDelegationAddParameter(),
+            Grpc.V2.RejectReason.ReasonOneofCase.MissingDelegationAddParameters => new MissingDelegationAddParameters(),
             Grpc.V2.RejectReason.ReasonOneofCase.InsufficientDelegationStake => new InsufficientDelegationStake(),
             Grpc.V2.RejectReason.ReasonOneofCase.DelegatorInCooldown => new DelegatorInCooldown(),
             Grpc.V2.RejectReason.ReasonOneofCase.NotADelegator => new NotADelegator(
@@ -351,7 +351,7 @@ public sealed record InsufficientBalanceForDelegationStake : IRejectReason;
 /// A configure delegation transaction is missing one or more arguments in
 /// order to add a delegator.
 /// </summary>
-public sealed record MissingDelegationAddParameter : IRejectReason;
+public sealed record MissingDelegationAddParameters : IRejectReason;
 /// <summary>
 /// Delegation stake when adding a delegator was 0.
 /// </summary>


### PR DESCRIPTION
## Purpose

Align libraries and correct plural names when necessary.

## Changes

Renamed record name to align which object mapped from.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.