### PR TITLE
Made to lower invariant and fixed minor bugs after gRPC update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased changes
+
+## 3.0.0
 - Added
   - Add optional cancellation token parameter to all client calls.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Currently, helpers for working with transactions of the [`Transfer`](http://deve
 The SDK is published on [nuget.org](https://www.nuget.org/packages/ConcordiumNetSdk). Depending on your setup, it can be added to your project as a dependency by running either
 
 ```powershell
-PM> Install-Package Concordium.SDK -Version 2.0
+PM> Install-Package Concordium.SDK -Version 3.0
 ```
 or
 

--- a/src/Concordium.Sdk.csproj
+++ b/src/Concordium.Sdk.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <PackageVersion>2.0.0</PackageVersion>
+    <PackageVersion>3.0.0</PackageVersion>
     <Description>
       A .NET integration library written in C# which adds support for
       constructing and sending various transactions, as well as querying
@@ -16,7 +16,7 @@
     <PackageTags>concordium;concordium-net-sdk;blockchain;sdk;</PackageTags>
     <Company>Concordium</Company>
     <PackageId>ConcordiumNetSdk</PackageId>
-    <Version>2.0.0</Version>
+    <Version>3.0.0</Version>
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>MPL-2.0</PackageLicenseExpression>

--- a/src/Types/AccountBakerPendingChange.cs
+++ b/src/Types/AccountBakerPendingChange.cs
@@ -19,7 +19,7 @@ public abstract record AccountBakerPendingChange
         return stakeBakerPendingChange.ChangeCase switch
         {
             StakePendingChange.ChangeOneofCase.Reduce =>
-                new AccountBakerReduceStakePending(CcdAmount.From(stakeBakerPendingChange.Reduce.NewStake), stakeBakerPendingChange.Remove.ToDateTimeOffset()),
+                new AccountBakerReduceStakePending(CcdAmount.From(stakeBakerPendingChange.Reduce.NewStake), stakeBakerPendingChange.Reduce.EffectiveTime.ToDateTimeOffset()),
             StakePendingChange.ChangeOneofCase.Remove =>
                 new AccountBakerRemovePending(stakeBakerPendingChange.Remove.ToDateTimeOffset())
             ,

--- a/src/Types/AccountStakingInfo.cs
+++ b/src/Types/AccountStakingInfo.cs
@@ -30,16 +30,16 @@ internal static class AccountStakingInfo
 /// The account is a baker.
 /// </summary>
 public sealed record AccountBaker(
-    BakerId BakerId,
-    AccountBakerPendingChange? PendingChange,
     bool RestakeEarnings,
     CcdAmount StakedAmount,
+    BakerInfo BakerInfo,
+    AccountBakerPendingChange? PendingChange,
     BakerPoolInfo? BakerPoolInfo
     ) : IAccountStakingInfo
 {
     internal static AccountBaker From(Grpc.V2.AccountStakingInfo.Types.Baker stakeBaker) =>
         new(
-            BakerId: BakerId.From(stakeBaker.BakerInfo.BakerId),
+            BakerInfo: BakerInfo.From(stakeBaker.BakerInfo),
             PendingChange: AccountBakerPendingChange.From(stakeBaker.PendingChange),
             RestakeEarnings: stakeBaker.RestakeEarnings,
             StakedAmount: CcdAmount.From(stakeBaker.StakedAmount),

--- a/src/Types/AccountTransactionEffects.cs
+++ b/src/Types/AccountTransactionEffects.cs
@@ -324,7 +324,7 @@ public sealed record DataRegistered(byte[] Data) : IAccountTransactionEffects
     /// <summary>
     /// Returns hex representation of data.
     /// </summary>
-    public string ToHex() => Convert.ToHexString(this.Data);
+    public string ToHex() => Convert.ToHexString(this.Data).ToLowerInvariant();
 }
 
 /// <summary>

--- a/src/Types/AccountTransactionEffects.cs
+++ b/src/Types/AccountTransactionEffects.cs
@@ -324,7 +324,7 @@ public sealed record DataRegistered(byte[] Data) : IAccountTransactionEffects
     /// <summary>
     /// Returns hex representation of data.
     /// </summary>
-    public string ToHex() => Convert.ToHexString(this.Data).ToLowerInvariant();
+    public string ToHexString() => Convert.ToHexString(this.Data).ToLowerInvariant();
 }
 
 /// <summary>

--- a/src/Types/BakerInfo.cs
+++ b/src/Types/BakerInfo.cs
@@ -1,0 +1,31 @@
+namespace Concordium.Sdk.Types;
+
+/// <summary>
+/// Information about a baker.
+/// </summary>
+/// <param name="BakerId">
+/// Identity of the baker. This is actually the account index of
+/// the account controlling the baker.
+/// </param>
+/// <param name="BakerElectionVerifyKey">
+/// Baker's public key used to check whether they won the lottery or not.
+/// </param>
+/// <param name="BakerSignatureVerifyKey"></param>
+/// <param name="BakerAggregationVerifyKey">
+/// Baker's public key used to check signatures on finalization records.
+/// This is only used if the baker has sufficient stake to participate in
+/// finalization.
+/// </param>
+public sealed record BakerInfo(BakerId BakerId,
+    byte[] BakerElectionVerifyKey,
+    byte[] BakerSignatureVerifyKey,
+    byte[] BakerAggregationVerifyKey)
+{
+    internal static BakerInfo From(Grpc.V2.BakerInfo bakerInfo) =>
+        new(
+            BakerId.From(bakerInfo.BakerId),
+            bakerInfo.ElectionKey.Value.ToByteArray(),
+            bakerInfo.SignatureKey.Value.ToByteArray(),
+            bakerInfo.AggregationKey.Value.ToByteArray()
+        );
+}

--- a/src/Types/BakerInfo.cs
+++ b/src/Types/BakerInfo.cs
@@ -3,10 +3,7 @@ namespace Concordium.Sdk.Types;
 /// <summary>
 /// Information about a baker.
 /// </summary>
-/// <param name="BakerId">
-/// Identity of the baker. This is actually the account index of
-/// the account controlling the baker.
-/// </param>
+/// <param name="BakerId">Account index of the account controlling the baker.</param>
 /// <param name="BakerElectionVerifyKey">
 /// Baker's public key used to check whether they won the lottery or not.
 /// </param>

--- a/src/Types/BakerPoolInfo.cs
+++ b/src/Types/BakerPoolInfo.cs
@@ -13,11 +13,17 @@ public sealed record BakerPoolInfo(
     BakerPoolOpenStatus OpenStatus,
     string MetadataUrl)
 {
-    internal static BakerPoolInfo From(Grpc.V2.BakerPoolInfo poolInfo) =>
-        new
-        (
+    internal static BakerPoolInfo? From(Grpc.V2.BakerPoolInfo? poolInfo)
+    {
+        if (poolInfo is null)
+        {
+            return null;
+        }
+
+        return new BakerPoolInfo(
             CommissionRates: CommissionRates.From(poolInfo.CommissionRates),
             OpenStatus: BakerPoolOpenStatus.OpenForAll,
             MetadataUrl: poolInfo.Url
         );
+    }
 }

--- a/src/Types/BakerPoolStatus.cs
+++ b/src/Types/BakerPoolStatus.cs
@@ -41,7 +41,7 @@ public sealed record BakerPoolStatus(
             CcdAmount.From(poolInfoResponse.EquityCapital),
             CcdAmount.From(poolInfoResponse.DelegatedCapital),
             CcdAmount.From(poolInfoResponse.DelegatedCapitalCap),
-            BakerPoolInfo.From(poolInfoResponse.PoolInfo),
+            BakerPoolInfo.From(poolInfoResponse.PoolInfo)!,
             CurrentPaydayBakerPoolStatus.From(poolInfoResponse.CurrentPaydayInfo),
             CcdAmount.From(poolInfoResponse.AllPoolTotalCapital));
 }

--- a/src/Types/ContractEvent.cs
+++ b/src/Types/ContractEvent.cs
@@ -8,5 +8,5 @@ public sealed record ContractEvent(byte[] Bytes)
     /// <summary>
     /// Return hex representation.
     /// </summary>
-    public string ToHex() => Convert.ToHexString(this.Bytes).ToLowerInvariant();
+    public string ToHexString() => Convert.ToHexString(this.Bytes).ToLowerInvariant();
 }

--- a/src/Types/ContractEvent.cs
+++ b/src/Types/ContractEvent.cs
@@ -8,5 +8,5 @@ public sealed record ContractEvent(byte[] Bytes)
     /// <summary>
     /// Return hex representation.
     /// </summary>
-    public string ToHex() => Convert.ToHexString(this.Bytes);
+    public string ToHex() => Convert.ToHexString(this.Bytes).ToLowerInvariant();
 }

--- a/src/Types/CredentialRegistrationID.cs
+++ b/src/Types/CredentialRegistrationID.cs
@@ -15,7 +15,7 @@ public sealed record CredentialRegistrationId(byte[] Id) : IAccountIdentifier
     /// Return hex string representation.
     /// </summary>
     /// <returns></returns>
-    public string ToHex() => Convert.ToHexString(this.Id).ToLowerInvariant();
+    public string ToHexString() => Convert.ToHexString(this.Id).ToLowerInvariant();
 
     internal static CredentialRegistrationId From(Grpc.V2.CredentialRegistrationId id) => new(id.Value.ToByteArray());
 

--- a/src/Types/CredentialRegistrationID.cs
+++ b/src/Types/CredentialRegistrationID.cs
@@ -15,7 +15,7 @@ public sealed record CredentialRegistrationId(byte[] Id) : IAccountIdentifier
     /// Return hex string representation.
     /// </summary>
     /// <returns></returns>
-    public string ToHex() => Convert.ToHexString(this.Id);
+    public string ToHex() => Convert.ToHexString(this.Id).ToLowerInvariant();
 
     internal static CredentialRegistrationId From(Grpc.V2.CredentialRegistrationId id) => new(id.Value.ToByteArray());
 

--- a/src/Types/Parameter.cs
+++ b/src/Types/Parameter.cs
@@ -8,5 +8,5 @@ public sealed record Parameter(byte[] Param)
     /// <summary>
     /// Convert parameters to hex string.
     /// </summary>
-    public string ToHex() => Convert.ToHexString(this.Param).ToLowerInvariant();
+    public string ToHexString() => Convert.ToHexString(this.Param).ToLowerInvariant();
 }

--- a/src/Types/Parameter.cs
+++ b/src/Types/Parameter.cs
@@ -8,5 +8,5 @@ public sealed record Parameter(byte[] Param)
     /// <summary>
     /// Convert parameters to hex string.
     /// </summary>
-    public string ToHexString() => Convert.ToHexString(this.Param);
+    public string ToHex() => Convert.ToHexString(this.Param).ToLowerInvariant();
 }

--- a/src/Types/RejectReason.cs
+++ b/src/Types/RejectReason.cs
@@ -284,7 +284,7 @@ public sealed record DuplicateCredIds(IList<byte[]> CredIds) : IRejectReason
     /// <summary>
     /// Return keys in hex representations.
     /// </summary>
-    public IEnumerable<string> ToHexStrings() => this.CredIds.Select(Convert.ToHexString);
+    public IEnumerable<string> ToHexStrings() => this.CredIds.Select(k => Convert.ToHexString(k).ToLowerInvariant());
 }
 
 /// <summary>
@@ -295,7 +295,7 @@ public sealed record NonExistentCredIds(IList<byte[]> CredIds) : IRejectReason
     /// <summary>
     /// Return keys in hex representations.
     /// </summary>
-    public IEnumerable<string> ToHexStrings() => this.CredIds.Select(Convert.ToHexString);
+    public IEnumerable<string> ToHexStrings() => this.CredIds.Select(k => Convert.ToHexString(k).ToLowerInvariant());
 }
 /// <summary>
 /// Attempt to remove the first credential

--- a/src/Types/Sha256Hash.cs
+++ b/src/Types/Sha256Hash.cs
@@ -12,5 +12,5 @@ public sealed record Sha256Hash : Hash
     /// <summary>
     /// Return hex representation of data.
     /// </summary>
-    public string ToHex() => Convert.ToHexString(this.AsSpan()).ToLowerInvariant();
+    public string ToHexString() => Convert.ToHexString(this.AsSpan()).ToLowerInvariant();
 }

--- a/src/Types/Sha256Hash.cs
+++ b/src/Types/Sha256Hash.cs
@@ -12,5 +12,5 @@ public sealed record Sha256Hash : Hash
     /// <summary>
     /// Return hex representation of data.
     /// </summary>
-    public string ToHex() => Convert.ToHexString(this.AsSpan());
+    public string ToHex() => Convert.ToHexString(this.AsSpan()).ToLowerInvariant();
 }

--- a/tests/IntegrationTests/Client/GetAccountInfo.cs
+++ b/tests/IntegrationTests/Client/GetAccountInfo.cs
@@ -1,0 +1,30 @@
+using Concordium.Sdk.Types;
+using FluentAssertions;
+using Xunit.Abstractions;
+
+namespace Concordium.Sdk.Tests.IntegrationTests.Client;
+
+[Trait("Category", "IntegrationTests")]
+public class GetAccountInfo : Tests
+{
+    public GetAccountInfo(ITestOutputHelper output) : base(output)
+    {}
+
+    [Fact]
+    public async Task GivenBakerZero_AtGenesisBlock_WhenGetAccountInfo_ThenReturnBakerZeroId()
+    {
+        // Arrange
+        var block = BlockHash.From("4221332d34e1694168c2a0c0b3fd0f273809612cb13d000d5c2e00e85f50f796");
+        var accountAddress = AccountAddress.From("48XGRnvQoG92T1AwETvW5pnJ1aRSPMKsWtGdKhTqyiNZzMk3Qn");
+
+        // Act
+        var accountInfoAsync = await this.Client.GetAccountInfoAsync(accountAddress, new Given(block));
+
+        // Assert
+        accountInfoAsync.Response.AccountStakingInfo.Should().NotBeNull();
+        accountInfoAsync.Response.AccountStakingInfo!.Should().BeOfType<AccountBaker>();
+        var baker = accountInfoAsync.Response.AccountStakingInfo! as AccountBaker;
+        baker!.BakerInfo.BakerId.Id.Index.Should().Be(0);
+    }
+
+}

--- a/tests/IntegrationTests/Client/GetAccountInfo.cs
+++ b/tests/IntegrationTests/Client/GetAccountInfo.cs
@@ -8,7 +8,7 @@ namespace Concordium.Sdk.Tests.IntegrationTests.Client;
 public class GetAccountInfo : Tests
 {
     public GetAccountInfo(ITestOutputHelper output) : base(output)
-    {}
+    { }
 
     [Fact]
     public async Task GivenBakerZero_AtGenesisBlock_WhenGetAccountInfo_ThenReturnBakerZeroId()


### PR DESCRIPTION
## Purpose

Made sure all call which creates Hex string make them to lower invariants.

This since from gRPC v1 we have from the nodes returned hex strings in lower invariants. Hence if some have stored these references in some storage and selecting using case sensitive queries, then their logic will be broken.

Changelog not updated since all changes in this PR only affects code which hasn’t been released yet.

## Changes

Make Hex strings consistent with earlier protocol.

Also fix minor bugs after gRPC update.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [-] (If necessary) I have updated the CHANGELOG.
