### PR TITLE
Updated SDK to align with Protocol 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## Unreleased changes
 
+## 4.0.0
+- The SDK requires node version 6 or later.
+### Breaking changes in types
+  - `ConsensusInfo`
+    - `SlotDuration` is now an nullable field, only present in protocols 1-5.
+    - a new field `ConcordiumBftDetails` is added, that is present if protocol
+      version is 6 or higher
+    - Bugfix: `BlockLastArrivedTime` was wrongly mapped from `BlockLastReceivedTime`.
+  - `BlockInfo`
+    - `BlockSlot` is nullable, and only present in protocols 1-5
+    - new fields `Round` and `Epoch` that are present in protocol 6 or higher.
+
+
 ## 3.0.0
 - Added
   - Add optional cancellation token parameter to all client calls.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,17 @@
 - The SDK requires node version 6 or later.
 - Breaking changes
   - `ConsensusInfo`
-    - `SlotDuration` is now an nullable field, only present in protocols 1-5.
+    - `SlotDuration` is now a nullable field, only present in protocols 1-5.
     - Bugfix: `BlockLastArrivedTime` was wrongly mapped from `BlockLastReceivedTime`.    
   - `BlockInfo`
-    - `BlockSlot` is nullable, and only present in protocols 1-5
+    - `BlockSlot` is now a nullable field, and only present in protocols 1-5
 - Added
   - `ConsensusInfo`
-    - a new field `ConcordiumBftDetails` is added, that is present if protocol
-      version is 6 or higher
+    - a new field `ConcordiumBftDetails` is added that is present if protocol version is 6 or higher
   - `BlockInfo`
     - new fields `Round` and `Epoch` that are present in protocol 6 or higher.
   - `BakerPoolStatus` 
-    - Added nullable `BakerPoolPendingChange` which is present if any change is pending on baker pool.
+    - a new field`BakerPoolPendingChange` is added which is present if any change is pending on baker pool.
 
 ## 3.0.0
 - Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
       version is 6 or higher
   - `BlockInfo`
     - new fields `Round` and `Epoch` that are present in protocol 6 or higher.
+  - `BakerPoolStatus` 
+    - Added nullable `BakerPoolPendingChange` which is present if any change is pending on baker pool.
 
 ## 3.0.0
 - Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,18 @@
 
 ## 4.0.0
 - The SDK requires node version 6 or later.
-### Breaking changes in types
+- Breaking changes
   - `ConsensusInfo`
     - `SlotDuration` is now an nullable field, only present in protocols 1-5.
-    - a new field `ConcordiumBftDetails` is added, that is present if protocol
-      version is 6 or higher
-    - Bugfix: `BlockLastArrivedTime` was wrongly mapped from `BlockLastReceivedTime`.
+    - Bugfix: `BlockLastArrivedTime` was wrongly mapped from `BlockLastReceivedTime`.    
   - `BlockInfo`
     - `BlockSlot` is nullable, and only present in protocols 1-5
+- Added
+  - `ConsensusInfo`
+    - a new field `ConcordiumBftDetails` is added, that is present if protocol
+      version is 6 or higher
+  - `BlockInfo`
     - new fields `Round` and `Epoch` that are present in protocol 6 or higher.
-
 
 ## 3.0.0
 - Added

--- a/src/Helpers/DateAndTimeExtensions.cs
+++ b/src/Helpers/DateAndTimeExtensions.cs
@@ -8,9 +8,5 @@ internal static class DateAndTimeExtensions
 
     internal static DateTimeOffset ToDateTimeOffset(this TransactionTime seconds) => DateTimeOffset.FromUnixTimeSeconds((long)seconds.Value);
 
-    /// <summary>
-    /// Durations from mapped from GRPC are given in milliseconds.
-    /// </summary>
-    /// <returns></returns>
     internal static TimeSpan ToTimeSpan(this Duration duration) => TimeSpan.FromMilliseconds(duration.Value);
 }

--- a/src/Helpers/DateAndTimeExtensions.cs
+++ b/src/Helpers/DateAndTimeExtensions.cs
@@ -2,9 +2,15 @@ using Concordium.Grpc.V2;
 
 namespace Concordium.Sdk.Helpers;
 
-internal static class TimestampExtensions
+internal static class DateAndTimeExtensions
 {
     internal static DateTimeOffset ToDateTimeOffset(this Timestamp timestamp) => DateTimeOffset.FromUnixTimeMilliseconds((long)timestamp.Value);
 
     internal static DateTimeOffset ToDateTimeOffset(this TransactionTime seconds) => DateTimeOffset.FromUnixTimeSeconds((long)seconds.Value);
+
+    /// <summary>
+    /// Durations from mapped from GRPC are given in milliseconds.
+    /// </summary>
+    /// <returns></returns>
+    internal static TimeSpan ToTimeSpan(this Duration duration) => TimeSpan.FromMilliseconds(duration.Value);
 }

--- a/src/Types/BakerPoolPendingChange.cs
+++ b/src/Types/BakerPoolPendingChange.cs
@@ -21,8 +21,7 @@ public abstract record BakerPoolPendingChange
             PoolPendingChange.ChangeOneofCase.Reduce =>
                 new BakerPoolReduceStakePending(CcdAmount.From(pendingChange.Reduce.ReducedEquityCapital), pendingChange.Reduce.EffectiveTime.ToDateTimeOffset()),
             PoolPendingChange.ChangeOneofCase.Remove =>
-                new BakerPoolRemovePending(pendingChange.Remove.EffectiveTime.ToDateTimeOffset())
-            ,
+                new BakerPoolRemovePending(pendingChange.Remove.EffectiveTime.ToDateTimeOffset()),
             PoolPendingChange.ChangeOneofCase.None => null,
             _ => throw new MissingEnumException<PoolPendingChange.ChangeOneofCase>(pendingChange.ChangeCase)
         };

--- a/src/Types/BakerPoolPendingChange.cs
+++ b/src/Types/BakerPoolPendingChange.cs
@@ -1,0 +1,46 @@
+using Concordium.Grpc.V2;
+using Concordium.Sdk.Exceptions;
+using Concordium.Sdk.Helpers;
+
+namespace Concordium.Sdk.Types;
+
+/// <summary>
+/// Pending change in the baker's stake.
+/// </summary>
+public abstract record BakerPoolPendingChange
+{
+    internal static BakerPoolPendingChange? From(PoolPendingChange? pendingChange)
+    {
+        if (pendingChange is null)
+        {
+            return null;
+        }
+
+        return pendingChange.ChangeCase switch
+        {
+            PoolPendingChange.ChangeOneofCase.Reduce =>
+                new BakerPoolReduceStakePending(CcdAmount.From(pendingChange.Reduce.ReducedEquityCapital), pendingChange.Reduce.EffectiveTime.ToDateTimeOffset()),
+            PoolPendingChange.ChangeOneofCase.Remove =>
+                new BakerPoolRemovePending(pendingChange.Remove.EffectiveTime.ToDateTimeOffset())
+            ,
+            PoolPendingChange.ChangeOneofCase.None => null,
+            _ => throw new MissingEnumException<PoolPendingChange.ChangeOneofCase>(pendingChange.ChangeCase)
+        };
+    }
+}
+
+/// <summary>
+/// The baker will be removed at the given time.
+/// </summary>
+/// <param name="EffectiveTime">Time when the baker will be removed.</param>
+public sealed record BakerPoolRemovePending(DateTimeOffset EffectiveTime) : BakerPoolPendingChange;
+/// <summary>
+/// The stake is being reduced. The new stake will take affect at the given time.
+/// </summary>
+/// <param name="NewStake">New stake which will take effect.</param>
+/// <param name="EffectiveTime">Time when the baker will be removed.</param>
+public sealed record BakerPoolReduceStakePending(CcdAmount NewStake, DateTimeOffset EffectiveTime) : BakerPoolPendingChange;
+
+
+
+

--- a/src/Types/BakerPoolStatus.cs
+++ b/src/Types/BakerPoolStatus.cs
@@ -23,6 +23,7 @@ namespace Concordium.Sdk.Types;
 /// if the pool is not a baker in the payday (e.g., because they just
 /// registered and a new payday has not started yet).
 /// </param>
+/// <param name="BakerStakePendingChange">Any pending change to the baker's stake.</param>
 /// <param name="AllPoolTotalCapital">Total capital staked across all pools.</param>
 public sealed record BakerPoolStatus(
         BakerId BakerId,
@@ -32,7 +33,8 @@ public sealed record BakerPoolStatus(
         CcdAmount DelegatedCapitalCap,
         BakerPoolInfo PoolInfo,
         CurrentPaydayBakerPoolStatus? CurrentPaydayStatus,
-        CcdAmount AllPoolTotalCapital)
+        CcdAmount AllPoolTotalCapital,
+        BakerPoolPendingChange? BakerStakePendingChange)
 {
     internal static BakerPoolStatus From(Grpc.V2.PoolInfoResponse poolInfoResponse) =>
         new(
@@ -43,7 +45,7 @@ public sealed record BakerPoolStatus(
             CcdAmount.From(poolInfoResponse.DelegatedCapitalCap),
             BakerPoolInfo.From(poolInfoResponse.PoolInfo)!,
             CurrentPaydayBakerPoolStatus.From(poolInfoResponse.CurrentPaydayInfo),
-            CcdAmount.From(poolInfoResponse.AllPoolTotalCapital));
+            CcdAmount.From(poolInfoResponse.AllPoolTotalCapital),
+            BakerPoolPendingChange.From(poolInfoResponse.EquityPendingChange)
+            );
 }
-
-

--- a/src/Types/BlockInfo.cs
+++ b/src/Types/BlockInfo.cs
@@ -28,7 +28,10 @@ namespace Concordium.Sdk.Types;
 /// Time when the block was added to the node's tree. This is a subjective
 /// (i.e., node specific) value.
 /// </param>
-/// <param name="BlockSlot">Slot number of the slot the block is in.</param>
+/// <param name="BlockSlot">
+/// Slot number of the slot the block is in.
+/// Present in protocol versions 1-5.
+/// </param>
 /// <param name="BlockSlotTime">
 /// Slot time of the slot the block is in. In contrast to
 /// <see cref="BlockArriveTime"/> this is an objective value, all nodes
@@ -44,6 +47,8 @@ namespace Concordium.Sdk.Types;
 /// <param name="TransactionSize">Size of all the transactions in the block in bytes.</param>
 /// <param name="BlockStateHash">Hash of the block state at the end of the given block.</param>
 /// <param name="ProtocolVersion">Protocol version to which the block belongs.</param>
+/// <param name="Round">The round of the block. Present from protocol version 6.</param>
+/// <param name="Epoch">The epoch of the block. Present from protocol version 6.</param>
 public sealed record BlockInfo(
     BlockHash BlockHash,
     BlockHash BlockParent,
@@ -53,7 +58,7 @@ public sealed record BlockInfo(
     ulong EraBlockHeight,
     DateTimeOffset BlockReceiveTime,
     DateTimeOffset BlockArriveTime,
-    ulong BlockSlot,
+    ulong? BlockSlot,
     DateTimeOffset BlockSlotTime,
     BakerId? BlockBaker,
     bool Finalized,
@@ -61,7 +66,9 @@ public sealed record BlockInfo(
     EnergyAmount TransactionEnergyCost,
     uint TransactionSize,
     StateHash BlockStateHash,
-    ProtocolVersion ProtocolVersion
+    ProtocolVersion ProtocolVersion,
+    Round? Round,
+    Epoch? Epoch
     )
 {
     internal static BlockInfo From(Grpc.V2.BlockInfo blockInfo) =>
@@ -74,7 +81,7 @@ public sealed record BlockInfo(
             EraBlockHeight: blockInfo.EraBlockHeight.Value,
             BlockReceiveTime: blockInfo.ReceiveTime.ToDateTimeOffset(),
             BlockArriveTime: blockInfo.ArriveTime.ToDateTimeOffset(),
-            BlockSlot: blockInfo.SlotNumber.Value,
+            BlockSlot: blockInfo.SlotNumber?.Value,
             BlockSlotTime: blockInfo.SlotTime.ToDateTimeOffset(),
             BlockBaker: blockInfo.Baker != null ? BakerId.From(blockInfo.Baker) : null,
             Finalized: blockInfo.Finalized,
@@ -82,6 +89,8 @@ public sealed record BlockInfo(
             TransactionEnergyCost: new EnergyAmount(blockInfo.TransactionsEnergyCost.Value),
             TransactionSize: blockInfo.TransactionsSize,
             BlockStateHash: new StateHash(blockInfo.StateHash.Value),
-            ProtocolVersion: blockInfo.ProtocolVersion.Into()
+            ProtocolVersion: blockInfo.ProtocolVersion.Into(),
+            Round: blockInfo.Round != null ? Types.Round.From(blockInfo.Round) : null,
+            Epoch: blockInfo.Epoch != null ? Types.Epoch.From(blockInfo.Epoch) : null
         );
 }

--- a/src/Types/ConcordiumBftDetails.cs
+++ b/src/Types/ConcordiumBftDetails.cs
@@ -1,0 +1,33 @@
+using Concordium.Sdk.Helpers;
+
+namespace Concordium.Sdk.Types;
+
+/// <summary>
+/// Parameters pertaining to the Concordium BFT consensus.
+/// </summary>
+/// <param name="CurrentTimeoutDuration">The current duration to wait before a round times out.</param>
+/// <param name="Round">The current round.</param>
+/// <param name="Epoch">The current epoch.</param>
+/// <param name="TriggerBlockTime">
+/// The first block in the epoch with timestamp at least this is considered
+/// to be the trigger block for the epoch transition.
+/// </param>
+public sealed record ConcordiumBftDetails(TimeSpan CurrentTimeoutDuration, Round CurrentRound, Epoch Epoch, DateTimeOffset TriggerBlockTime)
+{
+    internal static bool TryFrom(Grpc.V2.ConsensusInfo info, out ConcordiumBftDetails? details)
+    {
+        if (info.CurrentTimeoutDuration == null || info.CurrentRound == null ||
+            info.CurrentEpoch == null || info.TriggerBlockTime == null)
+        {
+            details = null;
+            return false;
+        }
+
+        details = new ConcordiumBftDetails(
+            info.CurrentTimeoutDuration.ToTimeSpan(),
+            Round.From(info.CurrentRound),
+            Epoch.From(info.CurrentEpoch),
+            info.TriggerBlockTime.ToDateTimeOffset());
+        return true;
+    }
+}

--- a/src/Types/ConcordiumBftDetails.cs
+++ b/src/Types/ConcordiumBftDetails.cs
@@ -6,28 +6,26 @@ namespace Concordium.Sdk.Types;
 /// Parameters pertaining to the Concordium BFT consensus.
 /// </summary>
 /// <param name="CurrentTimeoutDuration">The current duration to wait before a round times out.</param>
-/// <param name="Round">The current round.</param>
-/// <param name="Epoch">The current epoch.</param>
+/// <param name="CurrentRound">The current round.</param>
+/// <param name="CurrentEpoch">The current epoch.</param>
 /// <param name="TriggerBlockTime">
-/// The first block in the epoch with timestamp at least this is considered
+/// The first block in the epoc with a timestamp equal to or later than this timestamp, is considered
 /// to be the trigger block for the epoch transition.
 /// </param>
-public sealed record ConcordiumBftDetails(TimeSpan CurrentTimeoutDuration, Round CurrentRound, Epoch Epoch, DateTimeOffset TriggerBlockTime)
+public sealed record ConcordiumBftDetails(TimeSpan CurrentTimeoutDuration, Round CurrentRound, Epoch CurrentEpoch, DateTimeOffset TriggerBlockTime)
 {
-    internal static bool TryFrom(Grpc.V2.ConsensusInfo info, out ConcordiumBftDetails? details)
+    internal static ConcordiumBftDetails? From(Grpc.V2.ConsensusInfo info)
     {
         if (info.CurrentTimeoutDuration == null || info.CurrentRound == null ||
             info.CurrentEpoch == null || info.TriggerBlockTime == null)
         {
-            details = null;
-            return false;
+            return null;
         }
 
-        details = new ConcordiumBftDetails(
+        return new ConcordiumBftDetails(
             info.CurrentTimeoutDuration.ToTimeSpan(),
             Round.From(info.CurrentRound),
             Epoch.From(info.CurrentEpoch),
             info.TriggerBlockTime.ToDateTimeOffset());
-        return true;
     }
 }

--- a/src/Types/ConsensusInfo.cs
+++ b/src/Types/ConsensusInfo.cs
@@ -140,11 +140,8 @@ public sealed record ConsensusInfo(
     ConcordiumBftDetails? ConcordiumBftDetails
     )
 {
-    internal static ConsensusInfo From(Grpc.V2.ConsensusInfo consensusInfo)
-    {
-        var _ = ConcordiumBftDetails.TryFrom(consensusInfo, out var concordiumBftDetails);
-
-        return new ConsensusInfo(
+    internal static ConsensusInfo From(Grpc.V2.ConsensusInfo consensusInfo) =>
+        new(
             BestBlock: BlockHash.From(consensusInfo.BestBlock),
             GenesisBlock: BlockHash.From(consensusInfo.GenesisBlock),
             GenesisTime: consensusInfo.GenesisTime.ToDateTimeOffset(),
@@ -175,6 +172,5 @@ public sealed record ConsensusInfo(
             LastFinalizedTime: consensusInfo.LastFinalizedTime?.ToDateTimeOffset(),
             FinalizationPeriodEma: consensusInfo.HasFinalizationPeriodEma ? consensusInfo.FinalizationPeriodEma : null,
             FinalizationPeriodEmsd: consensusInfo.HasFinalizationPeriodEmsd ? consensusInfo.FinalizationPeriodEmsd : null,
-            ConcordiumBftDetails: concordiumBftDetails);
-    }
+            ConcordiumBftDetails: ConcordiumBftDetails.From(consensusInfo));
 }

--- a/src/Types/ConsensusInfo.cs
+++ b/src/Types/ConsensusInfo.cs
@@ -23,7 +23,10 @@ namespace Concordium.Sdk.Types;
 /// <see cref="GenesisBlock"/>.
 /// </param>
 /// <param name="CurrentEraGenesisTime">Time when the current era started.</param>
-/// <param name="SlotDuration">Duration of a slot.</param>
+/// <param name="SlotDuration">
+/// Duration of a slot.
+/// Present only in protocol versions 1-5.
+/// </param>
 /// <param name="EpochDuration">Duration of an epoch.</param>
 /// <param name="GenesisIndex">
 /// The number of chain restarts via a protocol update. An effected
@@ -99,6 +102,10 @@ namespace Concordium.Sdk.Types;
 /// finalizations. Will be `None` if there are no finalizations yet
 /// since the node start.
 /// </param>
+/// <param name="ConcordiumBftDetails">
+/// Parameters that apply from protocol 6 onward. This is present if and
+/// only if the protocol version is <see cref="ProtocolVersion.P6"/> or later.
+/// </param>
 public sealed record ConsensusInfo(
     BlockHash BestBlock,
     BlockHash GenesisBlock,
@@ -109,7 +116,7 @@ public sealed record ConsensusInfo(
     ProtocolVersion ProtocolVersion,
     BlockHash CurrentEraGenesisBlock,
     DateTimeOffset CurrentEraGenesisTime,
-    TimeSpan SlotDuration,
+    TimeSpan? SlotDuration,
     TimeSpan EpochDuration,
     uint GenesisIndex,
     uint BlocksReceivedCount,
@@ -129,12 +136,15 @@ public sealed record ConsensusInfo(
     ulong FinalizationCount,
     DateTimeOffset? LastFinalizedTime,
     double? FinalizationPeriodEma,
-    double? FinalizationPeriodEmsd
+    double? FinalizationPeriodEmsd,
+    ConcordiumBftDetails? ConcordiumBftDetails
     )
 {
-    internal static ConsensusInfo From(Grpc.V2.ConsensusInfo consensusInfo) =>
-        new
-        (
+    internal static ConsensusInfo From(Grpc.V2.ConsensusInfo consensusInfo)
+    {
+        var _ = ConcordiumBftDetails.TryFrom(consensusInfo, out var concordiumBftDetails);
+
+        return new ConsensusInfo(
             BestBlock: BlockHash.From(consensusInfo.BestBlock),
             GenesisBlock: BlockHash.From(consensusInfo.GenesisBlock),
             GenesisTime: consensusInfo.GenesisTime.ToDateTimeOffset(),
@@ -144,8 +154,8 @@ public sealed record ConsensusInfo(
             ProtocolVersion: consensusInfo.ProtocolVersion.Into(),
             CurrentEraGenesisBlock: BlockHash.From(consensusInfo.CurrentEraGenesisBlock),
             CurrentEraGenesisTime: consensusInfo.CurrentEraGenesisTime.ToDateTimeOffset(),
-            SlotDuration: TimeSpan.FromMilliseconds(consensusInfo.SlotDuration.Value),
-            EpochDuration: TimeSpan.FromMilliseconds(consensusInfo.EpochDuration.Value),
+            SlotDuration: consensusInfo.SlotDuration?.ToTimeSpan(),
+            EpochDuration: consensusInfo.EpochDuration.ToTimeSpan(),
             GenesisIndex: consensusInfo.GenesisIndex.Value,
             BlocksReceivedCount: consensusInfo.BlocksReceivedCount,
             BlockLastReceivedTime: consensusInfo.BlockLastReceivedTime?.ToDateTimeOffset(),
@@ -154,7 +164,7 @@ public sealed record ConsensusInfo(
             BlockReceivePeriodEma: consensusInfo.HasBlockReceivePeriodEma ? consensusInfo.BlockReceivePeriodEma : null,
             BlockReceivePeriodEmsd: consensusInfo.HasBlockReceivePeriodEmsd ? consensusInfo.BlockReceivePeriodEmsd : null,
             BlocksVerifiedCount: consensusInfo.BlocksVerifiedCount,
-            BlockLastArrivedTime: consensusInfo.BlockLastReceivedTime?.ToDateTimeOffset(),
+            BlockLastArrivedTime: consensusInfo.BlockLastArrivedTime?.ToDateTimeOffset(),
             BlockArriveLatencyEma: consensusInfo.BlockArriveLatencyEma,
             BlockArriveLatencyEmsd: consensusInfo.BlockArriveLatencyEmsd,
             BlockArrivePeriodEma: consensusInfo.HasBlockArrivePeriodEma ? consensusInfo.BlockArrivePeriodEma : null,
@@ -164,6 +174,7 @@ public sealed record ConsensusInfo(
             FinalizationCount: consensusInfo.FinalizationCount,
             LastFinalizedTime: consensusInfo.LastFinalizedTime?.ToDateTimeOffset(),
             FinalizationPeriodEma: consensusInfo.HasFinalizationPeriodEma ? consensusInfo.FinalizationPeriodEma : null,
-            FinalizationPeriodEmsd: consensusInfo.HasFinalizationPeriodEmsd ? consensusInfo.FinalizationPeriodEmsd : null
-        );
+            FinalizationPeriodEmsd: consensusInfo.HasFinalizationPeriodEmsd ? consensusInfo.FinalizationPeriodEmsd : null,
+            ConcordiumBftDetails: concordiumBftDetails);
+    }
 }

--- a/src/Types/Round.cs
+++ b/src/Types/Round.cs
@@ -1,0 +1,10 @@
+namespace Concordium.Sdk.Types;
+
+/// <summary>
+/// Round number. Applies to protocol 6 and onward.
+/// </summary>
+/// <param name="RoundNumber"></param>
+public readonly record struct Round(ulong RoundNumber)
+{
+    internal static Round From(Grpc.V2.Round round) => new(round.Value);
+}


### PR DESCRIPTION
## Purpose

Update SDK to align with new consensus protocol and hence changes done in gRPC API
https://github.com/Concordium/concordium-grpc-api/commit/13e23942735a427b188b6a27909044ff6493f50a.

This PR at the same time prepare for release 4.0.0.

## Changes

  - `ConsensusInfo`
    - `SlotDuration` is now an nullable field, only present in protocols 1-5.
    - a new field `ConcordiumBftDetails` is added, that is present if protocol
      version is 6 or higher
    - Bugfix: `BlockLastArrivedTime` was wrongly mapped from `BlockLastReceivedTime`.
  - `BlockInfo`
    - `BlockSlot` is nullable, and only present in protocols 1-5
    - new fields `Round` and `Epoch` that are present in protocol 6 or higher.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.