### PR TITLE
Bug fix found under CCD Scan Protocol 6 update regression test 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased changes
 
+## 4.0.1
+- Bugfix
+  - `TransactionCount` in `BlockInfo` had wrong mapping and used `TransactionsSize` from node.
+
 ## 4.0.0
 - The SDK requires node version 6 or later.
 - Breaking changes

--- a/src/Concordium.Sdk.csproj
+++ b/src/Concordium.Sdk.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <PackageVersion>4.0.0</PackageVersion>
+    <PackageVersion>4.0.1</PackageVersion>
     <Description>
       A .NET integration library written in C# which adds support for
       constructing and sending various transactions, as well as querying
@@ -16,7 +16,7 @@
     <PackageTags>concordium;concordium-net-sdk;blockchain;sdk;</PackageTags>
     <Company>Concordium</Company>
     <PackageId>ConcordiumNetSdk</PackageId>
-    <Version>4.0.0</Version>
+    <Version>4.0.1</Version>
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>MPL-2.0</PackageLicenseExpression>

--- a/src/Types/BlockInfo.cs
+++ b/src/Types/BlockInfo.cs
@@ -85,7 +85,7 @@ public sealed record BlockInfo(
             BlockSlotTime: blockInfo.SlotTime.ToDateTimeOffset(),
             BlockBaker: blockInfo.Baker != null ? BakerId.From(blockInfo.Baker) : null,
             Finalized: blockInfo.Finalized,
-            TransactionCount: blockInfo.TransactionsSize,
+            TransactionCount: blockInfo.TransactionCount,
             TransactionEnergyCost: new EnergyAmount(blockInfo.TransactionsEnergyCost.Value),
             TransactionSize: blockInfo.TransactionsSize,
             BlockStateHash: new StateHash(blockInfo.StateHash.Value),

--- a/tests/IntegrationTests/Client/GetBlockInfo.cs
+++ b/tests/IntegrationTests/Client/GetBlockInfo.cs
@@ -13,6 +13,20 @@ public sealed class GetBlockInfo : Tests
     }
 
     [Fact]
+    public async Task GivenBlockWithOneTransaction_WhenGetBlockInfo_ThenTransactionCountOne()
+    {
+        // Arrange
+        var blochHashString = this.GetString("blockHashOneTransaction");
+
+
+        // Act
+        var info = await this.Client.GetBlockInfoAsync(new Given(BlockHash.From(blochHashString)));
+
+        // Assert
+        info.Response.TransactionCount.Should().Be(1);
+    }
+
+    [Fact]
     public async Task GivenAbsoluteHeightAboveBlockHeight_WhenCallGetBlockInfo_ThenThrowException()
     {
         // Arrange


### PR DESCRIPTION
## Purpose

Bugfix found when doing regression change on CCD Scan due to protocol 6 update.

## Changes

* https://concordium.atlassian.net/browse/CBW-1230
   `TransactionCount` in `BlockInfo` had wrong mapping and used `TransactionsSize` from node.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
