### PR TITLE
Add missing documentation when project is packaged.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased changes
+- Bugfix
+  - Documentation was missing when adding library as nuget packages and hovering over methods and classes.
 
 ## 4.0.1
 - Bugfix

--- a/src/Concordium.Sdk.csproj
+++ b/src/Concordium.Sdk.csproj
@@ -21,6 +21,9 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>MPL-2.0</PackageLicenseExpression>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DocumentationFile>bin\Release\net6.0\Concordium.Sdk.xml</DocumentationFile>
+  </PropertyGroup>
 
   <ItemGroup>
     <None Include="..\nuget\icon.png">

--- a/src/Concordium.Sdk.csproj
+++ b/src/Concordium.Sdk.csproj
@@ -20,9 +20,7 @@
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>MPL-2.0</PackageLicenseExpression>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DocumentationFile>bin\Release\net6.0\Concordium.Sdk.xml</DocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Purpose

Documentation was missing when adding library as nuget packages and hovering over methods and classes.

## Changes

Added documentation when project is packaged.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.