### PR TITLE
Fix native libraries build.

### DIFF
--- a/rust-bindings/Cargo.toml
+++ b/rust-bindings/Cargo.toml
@@ -8,7 +8,7 @@ exclude = ["test-data/*"]
 
 [lib]
 name="rust_bindings"
-crate-type = ["dylib"]
+crate-type = ["cdylib"]
 
 [dependencies]
 anyhow="1.0"
@@ -18,3 +18,6 @@ concordium-contracts-common = { version = "8.1.1", features = ["derive-serde"], 
 
 [dev-dependencies]
 hex = "0.4"
+
+[profile.release]
+rpath = true


### PR DESCRIPTION
## Purpose

Attempt to fix the native libraries build.

The output of `otool` after the changes does not mention `deps/librust_bindings.dylib'`.

```
tool -L target/release/librust_bindings.dylib
target/release/librust_bindings.dylib:
	@rpath/librust_bindings.dylib (compatibility version 0.0.0, current version 0.0.0)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 2202.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1336.61.1)
```

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
