### PR TITLE
Prepare release 4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased changes
 
+## 4.2.1
+- Bugfix
+  - Fix wrong build of rust dependencies which made the interops call not work on iOS.
+
 ## 4.2.0
 - Added
   - Deserialization from module schema

--- a/src/Concordium.Sdk.csproj
+++ b/src/Concordium.Sdk.csproj
@@ -15,7 +15,7 @@
     <PackageTags>concordium;concordium-net-sdk;blockchain;sdk;</PackageTags>
     <Company>Concordium</Company>
     <PackageId>ConcordiumNetSdk</PackageId>
-    <Version>4.2.0</Version>
+    <Version>4.2.1</Version>
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>MPL-2.0</PackageLicenseExpression>


### PR DESCRIPTION
## Purpose

Prepare release 4.2.1 which includes the fix for building rust dependency correct for iOS.

## Checklist

- [x] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.