### PR TITLE
Change pipelines to use ubuntu 20.04

### DIFF
--- a/.github/workflows/build-test-format.yml
+++ b/.github/workflows/build-test-format.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   rustfmt:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v4
@@ -29,7 +29,7 @@ jobs:
 
   rustclippy-build-test:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
     publish-docs:
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-20.04
       steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   build-native-ubuntu:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v3
@@ -72,7 +72,7 @@ jobs:
 
   build-and-release:
     needs: [build-native-ubuntu, build-native-macos, build-native-windows]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     environment: release
 
     steps:


### PR DESCRIPTION
## Purpose

Solves issue: https://github.com/Concordium/concordium-net-sdk/issues/87

Validated works by setting `<RunRustBuild>false</RunRustBuild>` in `src/Concordium.Sdk.csproj` and then run unit test, which contains test for FFI, in default dotnet 6 image.

Dockerfile below was used with command `docker build . --progress=plain`

```
FROM ubuntu:20.04 as ubuntu-builder

ENV DEBIAN_FRONTEND=noninteractive

RUN apt-get update && apt-get install -y \
    curl \
    build-essential \
    && rm -rf /var/lib/apt/lists/*

RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
ENV PATH=/root/.cargo/bin:$PATH

WORKDIR /src
COPY concordium-base/ concordium-base/
COPY rust-bindings/ rust-bindings/

RUN cargo build --manifest-path=./rust-bindings/Cargo.toml --release

FROM mcr.microsoft.com/dotnet/sdk:6.0
WORKDIR /app
COPY --from=ubuntu-builder /src/rust-bindings rust-bindings
COPY concordium-base/ concordium-base/
COPY src/ src/
COPY tests/ tests/

WORKDIR "/app/tests/UnitTests"

RUN dotnet restore
RUN dotnet build --no-restore
RUN dotnet test "Concordium.Sdk.Tests.UnitTests.csproj" --filter FullyQualifiedName!~IntegrationTests --no-build --verbosity normal
```