### PR TITLE
Fix namespace links

### DIFF
--- a/docs/api/Concordium.Grpc.md
+++ b/docs/api/Concordium.Grpc.md
@@ -1,0 +1,3 @@
+---
+redirect_url: Concordium.Grpc.V2.html
+---

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -18,7 +18,7 @@
       "disableGitFeatures": false,
       "disableDefaultFilter": false,
       "noRestore": false,
-      "namespaceLayout": "flattened",
+      "namespaceLayout": "nested",
       "memberLayout": "samePage",
       "allowCompilationErrors": false
     }
@@ -29,6 +29,7 @@
         "files": [
           "api/**.yml",
           "api/index.md",
+          "api/Concordium.Grpc.md",
           "toc.yml",
           "index.md"
         ]


### PR DESCRIPTION
## Purpose

Clicking the links in the namespace returns 404.

![image](https://github.com/user-attachments/assets/ada70627-d8e6-4546-8c26-0b8f511320c2)


## Changes

Changed to using nested namespace, this seems to generate the pages for the namespaces.

Flattened:
<img width="299" alt="image" src="https://github.com/user-attachments/assets/8fe6c6d1-478d-4ec0-a64e-9616650119bd" />

Nested:
<img width="290" alt="image" src="https://github.com/user-attachments/assets/a4641244-c20c-4c9a-8e82-fec5fcfd2652" />


Added redirect for `Concordium.Grpc`, as the namespace is called `Grpc.V2` it behaves weirdly in the link.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
